### PR TITLE
Fixed a colcon build bug in ROS2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/config', ['config/team_config.json', 'config/banner.txt']),
-        (os.path.join('share', package_name, 'assets/peg_in_hole'), glob('assets/peg_in_hole/*')),
     ]+ [
         # place files preserving relative paths under share/my_tasks_pkg/assets
         ("share/" + package_name + "/assets/" + str(p.parent.relative_to("assets")), [str(p)])


### PR DESCRIPTION
There's a redundant line in `setup.py` leading to a `colcon build` error:
```
$ colcon build
Starting >>> mnet_client
--- stderr: mnet_client
error: can't copy 'assets/peg_in_hole/cad_files': doesn't exist or not a regular file
```
This pull request deleted the redundant line and fixed this bug.